### PR TITLE
fix: Fix the handler within the httpd role to ensure it executes as expected

### DIFF
--- a/lamp.yml
+++ b/lamp.yml
@@ -13,4 +13,8 @@
   hosts: web
   roles:
   - { role: roles/httpd, tags: apache }
+
+- <<: *default_config
+  hosts: web
+  roles:
   - { role: roles/php, tags: php }

--- a/roles/php/vars/main.yml
+++ b/roles/php/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 
+apache_service: httpd
+
 php_packages:
 - php
 - php-cli


### PR DESCRIPTION
When you use the roles option at the play level, Ansible treats the roles as static imports and processes them during playbook parsing.

Ansible treats the roles used at the play level as static imports. This can result in the handler within the `httpd role` not being executed under certain unexpected situations, possibly due to conflicts with the handlers within the `php roles`.

## Error Message
The `Restart apache server` handler is not executing as expected, leading to the httpd service not running during the lab.
```
RUNNING HANDLER [roles/httpd : Test if Apache is installed and running] ***********************************************************************************************************************
fatal: [192.168.2.58]: FAILED! => {"changed": false, "content": "", "elapsed": 0, "msg": "Status code was -1 and not [200]: Request failed: <urlopen error [Errno 111] Connection refused>", "redirected": false, "status": -1, "url": "http://localhost:80"}
```

## Solution
The alternative way is split the httpd role and php role into two plays.